### PR TITLE
 Replaced object-assign-deep with lodash/merge

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1,5 +1,4 @@
 var _ = require('lodash');
-var objectAssignDeep = require('object-assign-deep');
 
 var ObjectId = require('bson-objectid');
 var debug = require('debug')('mongo-mock:collection');
@@ -493,10 +492,10 @@ function restoreObjectIDs(originalValue, updatedValue) {
 function upsertClone (selector, data) {
   if (data.$setOnInsert) {
     var dataToClone = {};
-    dataToClone.$set = objectAssignDeep({}, data.$set, data.$setOnInsert);
-    return objectAssignDeep({}, modifyjs({}, selector || {}), modifyjs({}, dataToClone));
+    dataToClone.$set = _.merge({}, data.$set, data.$setOnInsert);
+    return _.merge({}, modifyjs({}, selector || {}), modifyjs({}, dataToClone));
   }
-  return objectAssignDeep({}, modifyjs({}, data || {}), modifyjs({}, selector || {}));
+  return _.merge({}, modifyjs({}, data || {}), modifyjs({}, selector || {}));
 }
 
 function first(query, collection) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "debug": "^2.1.3",
     "lodash": "^4.17.10",
     "modifyjs": "^0.3.1",
-    "object-assign-deep": "^0.4.0",
     "sift": "^3.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
`object-assign-deep` package does not respect dates and other custom types of objects so it was replaced with `lodash/merge`